### PR TITLE
fix error, if a new file is added to repo

### DIFF
--- a/resources/updateManager.py
+++ b/resources/updateManager.py
@@ -45,7 +45,8 @@ def checkforupdates():
                 if not os.path.isdir(destdir):
                     os.makedirs(destdir)
                 data = updateFile.read(n)
-                os.remove(dest)
+                if os._exists(dest):
+                    os.remove(dest)
                 f = open(dest, 'w')
                 f.write(data)
                 f.close()


### PR DESCRIPTION
Wenn eine neue Datei in der Repo ist, gibt es hier ein Problem beim löschen der alten, da diese nicht vorhanden ist.
